### PR TITLE
handle pending payment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -118,7 +118,8 @@ $payload->metaData = [
 
 ```php
 public function handle(OpnPaymentCompleted $event) {
-    $attempt = $event->attempt;
+     $attempt = $event->attempt;
+    $charge = $event->charge;
     if ($attempt->payment_successful) {
         // handle payment success here
     } else {
@@ -127,11 +128,15 @@ public function handle(OpnPaymentCompleted $event) {
 }
 ```
 
-**To get last charge of payment attempt, you can do**
+## Scheduler
+Register scheduler for pending charges.
 
+This scheduler will get all pending charge from records withing 24 hours.\ 
+Then it will fetch status from Opn API and update if success or failed.
+
+In `app/Console/Kernel.php` inside `schedule()` function add below line.
 ```php
-$charge = $attempt->charge();
-$opnChargeId = $charge->charge_id;
+$schedule->command('opn-payments-scheduler')->everyFiveMinutes();
 ```
 
 ## Contribute

--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,7 @@ $payload->metaData = [
 ```php
 public function handle(OpnPaymentCompleted $event) {
     $attempt = $event->attempt;
+    $charge = $event->charge;
     if ($attempt->payment_successful) {
         // handle payment success here
     } else {
@@ -128,11 +129,15 @@ public function handle(OpnPaymentCompleted $event) {
 }
 ```
 
-**To get last charge of payment attempt, you can do**
+## Scheduler
+Register scheduler for pending charges.
 
+This scheduler will get all pending charge from records withing 24 hours.\ 
+Then it will fetch status from Opn API and update if success or failed. 
+
+In `app/Console/Kernel.php` inside `schedule()` function add below line.
 ```php
-$charge = $attempt->charge();
-$opnChargeId = $charge->charge_id;
+$schedule->command('opn-payments-scheduler')->everyFiveMinutes();
 ```
 
 ## Contribute

--- a/src/Commands/OpnPaymentsScheduler.php
+++ b/src/Commands/OpnPaymentsScheduler.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace OpnPayments\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use OpnPayments\Events\OpnPaymentCompleted;
+use OpnPayments\Models\OpnPaymentsAttempt;
+use OpnPayments\Models\OpnPaymentsCharge;
+use OpnPayments\OpnPayments;
+
+class OpnPaymentsScheduler extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'opn-payments-scheduler';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Opn Payments pending charge handler';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $paymentAttempts = OpnPaymentsAttempt::where('payment_successful', 0)
+            ->whereHas('charges', function($query) {
+                $query->where('status', 'pending')
+                ->where('created_at', '>', now()->subHours(24));
+            })
+            ->limit(10)
+            ->get();
+
+        foreach($paymentAttempts as $paymentAttempt) {
+            $charges = $paymentAttempt->pendingCharges;
+            foreach ($charges as $charge) {
+                $this->completeCharge($charge, $paymentAttempt);
+            }
+        }
+    }
+
+    public function completeCharge($charge, $paymentAttempt) {
+        $this->info('Checking Charge ID : ' . $charge->charge_id);
+        $chargeResult = OpnPayments::charge()->retrieve($charge->charge_id);
+        $paymentSuccessful = OpnPayments::paymentSuccessful($chargeResult, $paymentAttempt);
+        $this->info('Payment Successful : ' . ($paymentSuccessful ? 'Yes' : 'No'));
+        $charge->payment_successful = $paymentSuccessful;
+        $charge->status             = $charge->status;
+        $charge->failure_code       = $charge->failure_code;
+        $charge->save();
+        $paymentAttempt->payment_successful = $paymentSuccessful;
+        $paymentAttempt->save();
+        if ($charge->status != OpnPaymentsCharge::STATUS_PENDING) {
+            OpnPaymentCompleted::dispatch($paymentAttempt, $charge);
+        }
+    }
+}

--- a/src/Controllers/PaymentController.php
+++ b/src/Controllers/PaymentController.php
@@ -190,7 +190,7 @@ class PaymentController extends Controller {
         $attempt->save();
 
         if ($charge->status != OpnPaymentsCharge::STATUS_PENDING) {
-            OpnPaymentCompleted::dispatch($attempt);
+            OpnPaymentCompleted::dispatch($attempt, $paymentCharge);
         }
         return $charge;
     }

--- a/src/Events/OpnPaymentCompleted.php
+++ b/src/Events/OpnPaymentCompleted.php
@@ -6,19 +6,22 @@ use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use OpnPayments\Models\OpnPaymentsAttempt;
+use OpnPayments\Models\OpnPaymentsCharge;
 
 class OpnPaymentCompleted {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public ?OpnPaymentsAttempt $attempt = null;
+    public ?OpnPaymentsCharge $charge = null;
 
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct(OpnPaymentsAttempt $attempt) {
+    public function __construct(OpnPaymentsAttempt $attempt, OpnPaymentsCharge $charge) {
         $this->attempt = $attempt;
+        $this->charge = $charge;
     }
 
     /**

--- a/src/Listeners/OpnPaymentHandler.php
+++ b/src/Listeners/OpnPaymentHandler.php
@@ -21,6 +21,7 @@ class OpnPaymentHandler {
      */
     public function handle(OpnPaymentCompleted $event) {
         $attempt = $event->attempt;
+        $charge = $event->charge;
         if ($attempt->payment_successful) {
             // handle payment success here
         } else {

--- a/src/Models/OpnPaymentsAttempt.php
+++ b/src/Models/OpnPaymentsAttempt.php
@@ -27,6 +27,15 @@ class OpnPaymentsAttempt extends Model {
         return $this->hasMany(OpnPaymentsCharge::class);
     }
 
+    public function pendingCharges() {
+        return $this->charges()
+            ->where('status', 'pending')
+            ->where('created_at', '>', now()->subHours(24))
+            ->orderBy('id', 'desc')
+            ->limit('5')
+            ->where('payment_successful', 0);
+    }
+
     public function charge($paymentMethod = null) {
         $query = $this->charges()->orderBy('id', 'desc');
         if (!empty($paymentMethod)) {

--- a/src/OpnPaymentsServiceProvider.php
+++ b/src/OpnPaymentsServiceProvider.php
@@ -3,6 +3,7 @@ namespace OpnPayments;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use OpnPayments\Commands\OpnPaymentsScheduler;
 use OpnPayments\Controllers\PaymentController;
 
 class OpnPaymentsServiceProvider extends ServiceProvider {
@@ -35,6 +36,8 @@ class OpnPaymentsServiceProvider extends ServiceProvider {
         $this->app->singleton(OpnPayments::class, function() {
             return OpnPayments::init();
         });
+
+        $this->commands([OpnPaymentsScheduler::class]);
 
         $prefix = config('opn-payments.route_prefix', 'opn-payments');
 


### PR DESCRIPTION
# Topic
Handle pending payment with scheduler

## Register scheduler for pending charges.

This scheduler will get all pending charge from records withing 24 hours.\ 
Then it will fetch status from Opn API and update if success or failed. 

In `app/Console/Kernel.php` inside `schedule()` function add below line.
```php
$schedule->command('opn-payments-scheduler')->everyFiveMinutes();
```
